### PR TITLE
contentSizeを調整

### DIFF
--- a/NavigationNotice/NavigationNotice.swift
+++ b/NavigationNotice/NavigationNotice.swift
@@ -115,6 +115,11 @@ open class NavigationNotice {
             view.addSubview(noticeView)
         }
         
+        override func viewDidLayoutSubviews() {
+            super.viewDidLayoutSubviews()
+            noticeView.contentSize.width = view.bounds.width
+        }
+        
         func setInterval(_ interval: TimeInterval) {
             hiddenTimeInterval = interval
             

--- a/NavigationNotice/NavigationNotice.swift
+++ b/NavigationNotice/NavigationNotice.swift
@@ -498,7 +498,6 @@ open class NavigationNotice {
         return self
     }
     
-    @discardableResult
     open func completion(_ completion: (() -> Void)?) {
         completionHandler = completion
     }


### PR DESCRIPTION
画面回転後に`noticeView`の`contentSize.width`が画面幅より大きくなってしまい、noticeが左右にスクロール可能になってしまうケースがあったので、`viewDidLayoutSubviews`で`contentSize.width`を調整する対応をいれました。

[再現方法]
1. iPhoneなどで画面がlandscape時にnotice表示
2. 画面を縦に回転

`contentSize.width`が元の方向のままになっているため`notice`が横方向にスクロール可能になってしまう。