### PR TITLE
Hide notice by swipe down

### DIFF
--- a/NavigationNotice/NavigationNotice.swift
+++ b/NavigationNotice/NavigationNotice.swift
@@ -51,6 +51,12 @@ open class NavigationNotice {
         fileprivate var contentView: UIView?
         fileprivate var autoHidden: Bool = false
         fileprivate var hiddenTimeInterval: TimeInterval = 0
+        /// interval until hiding set by `setInterval(_:)`
+        private var _hiddenTimeInterval: TimeInterval = 0 {
+            didSet {
+                hiddenTimeInterval = _hiddenTimeInterval
+            }
+        }
         fileprivate var contentHeight: CGFloat {
             return noticeView.bounds.height
         }
@@ -121,7 +127,7 @@ open class NavigationNotice {
         }
         
         func setInterval(_ interval: TimeInterval) {
-            hiddenTimeInterval = interval
+            _hiddenTimeInterval = interval
             
             if interval >= 0 {
                 autoHidden = true
@@ -266,7 +272,6 @@ open class NavigationNotice {
                 
                 if isHideIfNeeded {
                     contentOffsetY = position == .top ? -contentHeight : contentHeight
-                    
                     hideIfNeeded(true)
                     return
                 }
@@ -284,9 +289,15 @@ open class NavigationNotice {
         func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
             let needsHideAnimation = (position == .top && contentOffsetY < 0) || (position == .bottom && contentOffsetY >= contentHeight)
             if needsHideAnimation {
-                hideIfNeeded(true)
+                resetTimerIfNeeded()
             } else {
                 hide(false)
+            }
+        }
+        
+        func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
+            if autoHidden == true && decelerate == false && hiddenTimeInterval == 0 {
+                timer(_hiddenTimeInterval)
             }
         }
         
@@ -307,6 +318,12 @@ open class NavigationNotice {
                 hide(animations, completion)
             } else {
                 UIView.animate(withDuration: 0.25, delay: 0, usingSpringWithDamping: 1, initialSpringVelocity: 1, options: .beginFromCurrentState, animations: animations, completion: completion)
+            }
+        }
+        
+        private func resetTimerIfNeeded() {
+            if autoHidden == true {
+                timer(_hiddenTimeInterval)
             }
         }
     }

--- a/NavigationNotice/NavigationNotice.swift
+++ b/NavigationNotice/NavigationNotice.swift
@@ -282,7 +282,7 @@ open class NavigationNotice {
         }
         
         func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
-            let needsHideAnimation = (position == .top && contentOffsetY < 0) || (position == .bottom && contentOffsetY >= 0)
+            let needsHideAnimation = (position == .top && contentOffsetY < 0) || (position == .bottom && contentOffsetY >= contentHeight)
             if needsHideAnimation {
                 hideIfNeeded(true)
             } else {

--- a/NavigationNotice/NavigationNotice.swift
+++ b/NavigationNotice/NavigationNotice.swift
@@ -51,12 +51,6 @@ open class NavigationNotice {
         fileprivate var contentView: UIView?
         fileprivate var autoHidden: Bool = false
         fileprivate var hiddenTimeInterval: TimeInterval = 0
-        /// interval until hiding set by `setInterval(_:)`
-        private var _hiddenTimeInterval: TimeInterval = 0 {
-            didSet {
-                hiddenTimeInterval = _hiddenTimeInterval
-            }
-        }
         fileprivate var contentHeight: CGFloat {
             return noticeView.bounds.height
         }
@@ -127,7 +121,7 @@ open class NavigationNotice {
         }
         
         func setInterval(_ interval: TimeInterval) {
-            _hiddenTimeInterval = interval
+            hiddenTimeInterval = interval
             
             if interval >= 0 {
                 autoHidden = true
@@ -152,7 +146,6 @@ open class NavigationNotice {
         func timer(_ interval: TimeInterval) {
             let handler: (CFRunLoopTimer?) -> Void = { [weak self] timer in
                 self?.hiddenTimer = nil
-                self?.hiddenTimeInterval = 0
                 
                 if self?.autoHidden == true {
                     if self?.panGesture.state != .changed && self?.scrollPanGesture?.state != .some(.changed) {
@@ -219,7 +212,7 @@ open class NavigationNotice {
         
         func hide(_ animated: Bool) {
             targetView?.removeGestureRecognizer(panGesture)
-            hiddenTimeInterval = 0
+            hiddenTimer = nil
             autoHidden = false
             
             if animated == true {
@@ -238,7 +231,7 @@ open class NavigationNotice {
         }
         
         func hideIfNeeded(_ animated: Bool) {
-            if autoHidden == true && hiddenTimeInterval <= 0 {
+            if autoHidden == true && hiddenTimer == nil {
                 hide(animated)
             }
         }
@@ -296,8 +289,8 @@ open class NavigationNotice {
         }
         
         func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
-            if autoHidden == true && decelerate == false && hiddenTimeInterval == 0 {
-                timer(_hiddenTimeInterval)
+            if autoHidden == true && decelerate == false && hiddenTimer == nil {
+                timer(hiddenTimeInterval)
             }
         }
         
@@ -323,7 +316,7 @@ open class NavigationNotice {
         
         private func resetTimerIfNeeded() {
             if autoHidden == true {
-                timer(_hiddenTimeInterval)
+                timer(hiddenTimeInterval)
             }
         }
     }


### PR DESCRIPTION
対応内容
- トーストが非表示にならないバグ
チケット：【トースト】トーストを下にスライドし、タップし続けるとトーストが表示されたままになります
- スワイプダウンで非表示にできないバグ
→スワイプダウンで`notice`を閉じる際の判定が`position == .bottom`の場合に間違っていたので、修正しました。